### PR TITLE
Lab exercise update

### DIFF
--- a/exercises/rhde_aw_120/0.1-upgrade-rhde/README.md
+++ b/exercises/rhde_aw_120/0.1-upgrade-rhde/README.md
@@ -13,7 +13,7 @@
 
 The purpose of this exercise is to review how RHDE is updated, and then automate this process. Once finished, you should be able to run a job template in Ansible Controller, specify the version of an image you'd like, and then let Ansible handle the rest.
 
-> Note:
+> **Note**
 >
 > This exercise is reused at a few different times throughout the workshop, so if you've already completed some of these steps, jump to [step 4](#step-4---running-the-upgrade-job).
 
@@ -88,7 +88,7 @@ Once you've finished creating playbook, commit and push it up into your code rep
 
 ### Step 3 - Creating a Job Template for our Upgrade Playbook
 
-> Note:
+> **Note**
 >
 > Ensure you've synced your project before attempting to create a job template.
 

--- a/exercises/rhde_aw_120/0.1-upgrade-rhde/README.md
+++ b/exercises/rhde_aw_120/0.1-upgrade-rhde/README.md
@@ -165,6 +165,6 @@ Confirm Input:
 ---
 **Navigation**
 
-[Continue to 4.3](../4.3-bare-metal-app-automation) | [Continue to 5.3](../5.3-containerized-app-automation) | [Continue to 6.3](../6.3-startup-k8s)
+[Continue to deploy on the OS](../4.3-bare-metal-app-automation) | [Continue to deploy containerized](../5.3-containerized-app-automation) | [Continue to deploy on MicroShift](../6.3-startup-k8s)
 
 [Click here to return to the Workshop Homepage](../README.md)

--- a/exercises/rhde_aw_120/1.1-preflight/README.md
+++ b/exercises/rhde_aw_120/1.1-preflight/README.md
@@ -30,7 +30,9 @@ In this lab, you work in a pre-configured lab environment and will have access t
 
 Since this is a shortened lab, the Image Builder related steps have already been completed, and images are hosted and ready for consumption.
 
-> Note: If you need more information on new Ansible Automation Platform components, bookmark this landing page [https://red.ht/AAP-20](https://red.ht/AAP-20)
+> **Note**
+>
+> If you need more information on new Ansible Automation Platform components, bookmark this landing page [https://red.ht/AAP-20](https://red.ht/AAP-20)
 
 ### Step 1 - Edge Device vs Virtual Device
 
@@ -53,7 +55,7 @@ It is highly encouraged that the Cockpit web interface be used to complete the w
 
 For more information on Cockpit, check out [Intro to Cockpit](https://www.redhat.com/sysadmin/intro-cockpit)
 
-> Note:
+> **Note**
 >
 > SSH access may be available as a backup, which provides access to the underlying tooling (such as virsh).
 

--- a/exercises/rhde_aw_120/1.1-preflight/README.md
+++ b/exercises/rhde_aw_120/1.1-preflight/README.md
@@ -46,7 +46,7 @@ Since this is a shortened lab, the Image Builder related steps have already been
 
 ### Step 3 - Accessing the Virtual Device Host
 
-A baremetal instance has been created in RHPDS that will host virtual instances meant to represent an edge device. Ask the lab instructor to provide login and authentication details along with any steps that you may need to complete.
+A baremetal instance has been created in RHPDS that will host virtual instances meant to represent an edge device. Your "Workbench Information" page that lists credentials to the various services includes a link to the Image Builder Cockpit interface. This is the machine on which your VMs are hosted. You can, alternatively, SSH to the instance using the Edge Manager SSH Access and interact with your VMs using traditional command line tooling, virt-manager with a remote connection configured on your host, or any other access method you might prefer.
 
 It is highly encouraged that the Cockpit web interface be used to complete the workshop exercises. Cockpit provides:
 - An easy to access interface to managing virtual machines running on RHEL
@@ -54,10 +54,6 @@ It is highly encouraged that the Cockpit web interface be used to complete the w
 - A web based console for bootstraping and troubleshooting
 
 For more information on Cockpit, check out [Intro to Cockpit](https://www.redhat.com/sysadmin/intro-cockpit)
-
-> **Note**
->
-> SSH access may be available as a backup, which provides access to the underlying tooling (such as virsh).
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/1.2-controller-intro/README.md
+++ b/exercises/rhde_aw_120/1.2-controller-intro/README.md
@@ -23,9 +23,13 @@ This exercise will cover
 
 ### Step 1 - Logging In
 
-> Note: If you are using an edge device on-site: your instructor will provide the IP address/DNS entry of the controller instance that will be running locally. Optionally, more information can be found on your student page.
+> **Note**
+>
+> If you are using an edge device on-site: your instructor will provide the IP address/DNS entry of the controller instance that will be running locally. Optionally, more information can be found on your student page.
 
-> Note: If you are using Controller in AWS: the login information can be found on your student page.
+> **Note**
+>
+> If you are using Controller in AWS: the login information can be found on your student page.
 
 After entering the URL in a browser, you will be greeted with the Ansible Controller login page. To log in, the username will be "student$(your_student_number)", such as `student1`, and the password is located on your student page.
 
@@ -49,7 +53,9 @@ Two credentials have been created for you:
 
 ![Credentials](../images/credentials.png)
 
-> Note: Be sure to save/remember the Device Credentials above, as they've been pre-baked into the edge images used throughout the lab for SSH access.
+> **Note**
+>
+> Be sure to save/remember the Device Credentials above, as they've been pre-baked into the edge images used throughout the lab for SSH access.
 
 ### Step 4 - Project
 
@@ -63,7 +69,9 @@ Two inventories have been created for you:
 1. Edge Utilities - systems used to support managing edge devices, and may also contain an edge hypervisor if one is provisioned for this workshop.
 2. Edge Systems - where our edge systems will live.
 
-> Note: The Edge Systems inventory is empty right now (Total Hosts = 0), because we haven't built anything yet. During the provisioning process, edge devices should appear in this inventory.
+> **Note**
+>
+> The Edge Systems inventory is empty right now (Total Hosts = 0), because we haven't built anything yet. During the provisioning process, edge devices should appear in this inventory.
 
 ![Inventories](../images/inventories.png)
 
@@ -79,7 +87,9 @@ An execution environment has been created that has all the necessary dependencie
 
 ![Execution Environments](../images/ee.png)
 
-> Note: The details of this execution environment can be found in the [code repository](https://github.com/redhat-manufacturing/device-edge-workshops/tree/main/execution-environment) for device edge workshops, and are built using [Ansible Builder](https://www.ansible.com/blog/introduction-to-ansible-builder).
+> **Note**
+>
+> The details of this execution environment can be found in the [code repository](https://github.com/redhat-manufacturing/device-edge-workshops/tree/main/execution-environment) for device edge workshops, and are built using [Ansible Builder](https://www.ansible.com/blog/introduction-to-ansible-builder).
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/1.2-controller-intro/README.md
+++ b/exercises/rhde_aw_120/1.2-controller-intro/README.md
@@ -49,13 +49,13 @@ Ensure you can view the details and access information of your organization unde
 
 Two credentials have been created for you:
 1. Gitea Credentials - to be used to sync projects from our code repository. These match the credentials used to log in to the Gitea web interface, which can be found on your student page. More information on Gitea will be provided in the next exercise.
-2. Device Credentials - a default set of credentials for connecting to edge devices. These default to `ansible:$(ssh_password)` found on your student page.
+2. Edge Manager SSH Credentials - to be used to access the hypervisor for managing our virtual machines. These are configured to use an SSH private key that was part of workshop setup.
 
 ![Credentials](../images/credentials.png)
 
 > **Note**
 >
-> Be sure to save/remember the Device Credentials above, as they've been pre-baked into the edge images used throughout the lab for SSH access.
+> The screenshot here doesn't exactly reflect what you should be seeing. The "Device Credentials" will come later.
 
 ### Step 4 - Project
 

--- a/exercises/rhde_aw_120/1.3-source-control-intro/README.md
+++ b/exercises/rhde_aw_120/1.3-source-control-intro/README.md
@@ -18,9 +18,13 @@ This exercise will cover:
 
 ### Step 1 - Logging In
 
-> Note: If you are using an edge device on-site: your instructor will provide the IP address/DNS entry of the Gitea instance that will be running locally. Optionally, more information can be found on your student page.
+> **Note**
+>
+> If you are using an edge device on-site: your instructor will provide the IP address/DNS entry of the Gitea instance that will be running locally. Optionally, more information can be found on your student page.
 
-> Note: If you are using Gitea in AWS: the login information can be found on your student page.
+> **Note**
+>
+> If you are using Gitea in AWS: the login information can be found on your student page.
 
 After entering the URL in a browser, you will be greeted with the Gitea login page. To log in, the username will be "student$(your_student_number)", such as `student1`, and the password located on your student page.
 
@@ -38,7 +42,9 @@ On the right-hand side of the Gitea dashboard is a link to a repository called `
 
 ![Device Edge Repo](../images/repo.png)
 
-> Note: The external SSH port for Gitea is `2222`. Be sure to append the correct port to `git` commands if using git over SSH instead of over http(s). For example `git clone ssh://git@g${gitea_server}:2222/student${your_student_number}/device-edge-codebase.git`
+> **Note**
+>
+> The external SSH port for Gitea is `2222`. Be sure to append the correct port to `git` commands if using git over SSH instead of over http(s). For example `git clone ssh://git@g${gitea_server}:2222/student${your_student_number}/device-edge-codebase.git`
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/1.3-source-control-intro/README.md
+++ b/exercises/rhde_aw_120/1.3-source-control-intro/README.md
@@ -38,7 +38,7 @@ Gitea features a lightweight dashboard that shows an activity stream and lists y
 
 ### Step 3 - The Device Edge Codebase Repo
 
-On the right-hand side of the Gitea dashboard is a link to a repository called `device-edge-codebase` which will be used to contain code for this workshop. Take a look at the pre-populated playbook in the `playbooks/` directory, and denote the http(s)/git addresses used to push and pull from this repository as it will be needed later on.
+On the right-hand side of the Gitea dashboard is a link to a repository called `device-edge-codebase` which will be used to contain code for this workshop. Take a look at the pre-populated playbook in the `playbooks/` directory, and take note of the http(s)/git addresses used to push and pull from this repository in the top right of the repository landing page.
 
 ![Device Edge Repo](../images/repo.png)
 

--- a/exercises/rhde_aw_120/1.4-device-intro/README.md
+++ b/exercises/rhde_aw_120/1.4-device-intro/README.md
@@ -39,7 +39,9 @@ An edge hypervisor may have been set up for this workshop to allow for a complet
 
 We'll be leveraging KVM and Cockpit on top of Red Hat Enterprise Linux to run our virtual edge devices. The URL and login information can be found on your student page.
 
-> Note: The URL will contain a port number (typically `:9090`). Ensure you include it when attempting to access the Cockpit WebUI from a browser.
+> **Note**
+>
+> The URL will contain a port number (typically `:9090`). Ensure you include it when attempting to access the Cockpit WebUI from a browser.
 
 After accessing the URL, you should be presented with the Cockpit login screen:
 
@@ -53,7 +55,9 @@ Ensure you can access the virtual machines tab:
 
 ![Cockpit Machines](../images/cockpit-machines.png)
 
-> Note: You have been given sudo access to this machine, so take caution when performing tasks on the hypervisor.
+> **Note**
+>
+> You have been given sudo access to this machine, so take caution when performing tasks on the hypervisor.
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/1.5-application-intro/README.md
+++ b/exercises/rhde_aw_120/1.5-application-intro/README.md
@@ -13,7 +13,7 @@
 
 ## Objective
 
-In this exercise, we are going to investigate the workload we'll be deploying to the edge device in various deployment configurations: baremetal, in containers on top of podman, and then on top of microshift.
+In this exercise, we are going to investigate the workload we'll be deploying to the edge device in various deployment configurations: installed directly into the Operating System, in containers managed with podman, and then on top of MicroShift.
 
 This exercise will cover:
 

--- a/exercises/rhde_aw_120/1.6-network-info/README.md
+++ b/exercises/rhde_aw_120/1.6-network-info/README.md
@@ -26,7 +26,7 @@ In addition, the devices will be connected to the same network (wired or wireles
 
 For edge devices being virtualized in AWS, the "edge manager" node is the same as the node running Ansible Controller. DNS/DHCP should be available within the VPC of the edge hypervisor, so simply reuse those details.
 
-> Note:
+> **Note**
 >
 > A quick reminder: your Ansible Controller information can be found on your student page.
 

--- a/exercises/rhde_aw_120/1.7-coding-intro/README.md
+++ b/exercises/rhde_aw_120/1.7-coding-intro/README.md
@@ -15,7 +15,7 @@ This exercise will cover:
 * Understanding where the repo is located
 * Cloning the git repo
 
-> Note:
+> **Note**
 >
 > This section is a bit ambiguous by design: feel free to use your laptop, SSH into the hypervisor node (if available), use your favorite IDE, sling code on the command line via VIM (which is better than Nano)... you're free to use whatever you're comfortable with. [VSCode](https://code.visualstudio.com/docs/setup/linux) + the [Ansible extension](https://marketplace.visualstudio.com/items?itemName=redhat.ansible) is a suggested approach.
 

--- a/exercises/rhde_aw_120/1.7-coding-intro/README.md
+++ b/exercises/rhde_aw_120/1.7-coding-intro/README.md
@@ -21,7 +21,7 @@ This exercise will cover:
 
 ### Step 1 - Reviewing the Code Repo Location
 
-Your git repository is located in Gitea, which can be accessed via a web interface for viewing, and can be authenticated to via username/password authentication over http. Feel free to also setup authentication via SSH keys if you so desire.
+Your git repository is located in Gitea, which can be accessed via a web interface for viewing, and can be authenticated to via username/password authentication over http. Feel free to also setup authentication via SSH keys if you so desire. You can access the settings to add an SSH key for your Gitea user by clicking on the arrow in the top right next to your randomly-generated profile picture, selecting "Settings," and heading to the "SSH / GPG Keys" tab. You can add any public key you have the private key for locally to this user and use this for local access - it doesn't impact the project sync configuration on the Controller.
 
 For a reminder on how to access Gitea, review  the [Investigating Source Control](../1.3-source-control-intro) exercise.
 

--- a/exercises/rhde_aw_120/2.1-kickstart-template/README.md
+++ b/exercises/rhde_aw_120/2.1-kickstart-template/README.md
@@ -18,6 +18,10 @@ We're writing this as a jinja2 template so that:
 1. Our kickstarts are fundamentally code, kept in source control, etc.
 2. We can use Ansible to push them out to anywhere.
 
+> **Note**
+>
+> Ensure you're building this template inside your project repository using whatever means you've decided to do that. Convention for an Ansible repository is that you place the template adjacent to your playbook in the `templates` directory, if you're not using a role - so consider creating that directory and placing it there.
+
 ### Step 1 - Kickstart Basics
 
 The most basic kickstart for Device Edge contains the following:

--- a/exercises/rhde_aw_120/2.1-kickstart-template/README.md
+++ b/exercises/rhde_aw_120/2.1-kickstart-template/README.md
@@ -68,7 +68,7 @@ ostreesetup --nogpg --url={{ ostree_repo_protocol }}://{{ ostree_repo_host }}:{{
 ```
 {% endraw %}
 
-> Note:
+> **Note**
 >
 > We are setting a root password due to a bug in RHEL, however we are locking the acocunt.
 

--- a/exercises/rhde_aw_120/2.1-kickstart-template/README.md
+++ b/exercises/rhde_aw_120/2.1-kickstart-template/README.md
@@ -106,7 +106,7 @@ network --bootproto=dhcp --onboot=true
 
 Take note that this is not part of `%pre` declaration, but it goes in the same section as the rest of of the kickstart options. Check the [solutions](#solutions) section for more info.
 
-## Step 4 - Creating a Call Home Playbook
+### Step 4 - Creating a Call Home Playbook
 
 Our kickstart file will install an operating system, but it does not yet include everything we would like it to contain. After devices boot up the first time, we want them to attempt to call home and register themselves with Ansible Controller so that they can be automated.
 

--- a/exercises/rhde_aw_120/2.2-kickstart-creds/README.md
+++ b/exercises/rhde_aw_120/2.2-kickstart-creds/README.md
@@ -329,7 +329,7 @@ Machine credential:
 
 ![Machine Credential](../images/machine-credential.png)
 
-> Note:
+> **Note**
 >
 > Some values may be different, depending on the lab environment. Refer any questions to the lab instructor.
 

--- a/exercises/rhde_aw_120/2.3-kickstart-playbook/README.md
+++ b/exercises/rhde_aw_120/2.3-kickstart-playbook/README.md
@@ -46,7 +46,7 @@ Once your playbook is constructed, push it up into your git repo.
 
 ### Step 2 - Creating a Job Template for our Playbook
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 > To sync the project, navigate to **Resources** > **Project** and click on the sync icon for the only project available
@@ -96,7 +96,7 @@ On the **Resources** > **Templates** page, select **Add** > **Add job template**
 
 Remember to click **Save**.
 
-> Note:
+> **Note**
 >
 > If you're not planning to kickstart over wifi, then the `Wireless Network Info` credential is not needed.
 

--- a/exercises/rhde_aw_120/2.4-build-iso/README.md
+++ b/exercises/rhde_aw_120/2.4-build-iso/README.md
@@ -30,6 +30,10 @@ Depending on the provisioned lab environment, the RHEL Boot ISO has already been
 
 If an edge hypervisor has been provisioned for you, then the RHEL Boot ISO is available on the system under `/opt/student-resources`. Copy it from that directory to somewhere in your home directory, such as `~/generate-iso/`.
 
+> **Note**
+>
+> You can either SSH to the edge hypervisor or access the terminal in the Cockpit UI to run your `cp` command.
+
 Otherwise, visit the [customer portal](https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.7/x86_64/product-software) and download the RHEL8.7 boot ISO. We won't need the full installation image as the boot ISO has everything necessary for provisioning our edge devices.
 
 ### Step 2 - Creating Customized Boot Options

--- a/exercises/rhde_aw_120/2.4-build-iso/README.md
+++ b/exercises/rhde_aw_120/2.4-build-iso/README.md
@@ -22,7 +22,7 @@ Ideally, once this ISO is built, the following should occur:
 
 The steps in this exercise are based on [this KB article](https://access.redhat.com/solutions/60959), which we'll walk through for reference. However, in the interest of time, we'll be using a script to generate the ISO.
 
-> Note:
+> **Note**
 >
 > A special thanks to Mr. James Harmison for the ISO generation script. Be sure to give him a hearty thank you the next time you see him.
 
@@ -85,7 +85,7 @@ First, ensure the following files are present in your directory:
 └── rhel-8.7-x86_64-boot.iso
 ```
 
-> Note:
+> **Note**
 >
 >  The filename containing the boot ISO will be called `rhel-8-boot.iso` if it was provided for you. Rename the file to match the name of the file in the directory structure shown above.
 
@@ -148,7 +148,7 @@ Once pasted in, make the script executable and then run it via sudo: `chmod ug+x
 
 After the script finishes, you should have a new iso called `rhde-ztp.iso` in your directory.
 
-> Note:
+> **Note**
 >
 > If the `mkisofs`, `isohybrid`, and `implantisomd5` commands aren't available, you may need to install the `genisoimage`, `syslinux`, and `isomd5sum` packages.
 

--- a/exercises/rhde_aw_120/2.4-build-iso/README.md
+++ b/exercises/rhde_aw_120/2.4-build-iso/README.md
@@ -22,10 +22,6 @@ Ideally, once this ISO is built, the following should occur:
 
 The steps in this exercise are based on [this KB article](https://access.redhat.com/solutions/60959), which we'll walk through for reference. However, in the interest of time, we'll be using a script to generate the ISO.
 
-> **Note**
->
-> A special thanks to Mr. James Harmison for the ISO generation script. Be sure to give him a hearty thank you the next time you see him.
-
 It's recommended to execute these steps either on your laptop if you have a physical device, or on the edge hypervisor if available, as those are the places where we'll need the customized ISO.
 
 ### Step 1 - Grabbing the RHEL Boot ISO

--- a/exercises/rhde_aw_120/2.5-device-config-automation/README.md
+++ b/exercises/rhde_aw_120/2.5-device-config-automation/README.md
@@ -40,7 +40,7 @@ Once complete, commit and push your new playbook up into Gitea.
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 

--- a/exercises/rhde_aw_120/2.5-device-config-automation/README.md
+++ b/exercises/rhde_aw_120/2.5-device-config-automation/README.md
@@ -19,9 +19,10 @@ Our tasks in the playbook will be:
 ### Step 1 - Writing Our Initial Device Configuration Playbook
 
 Return to your code repository and create a new playbook in the `playbooks` directory called `initial-device-config.yml`. Enter the following contents:
+
+{% raw %}
 ```yaml
 ---
-
 - name: do initial device setup
   hosts: all
   tasks:
@@ -35,6 +36,7 @@ Return to your code repository and create a new playbook in the `playbooks` dire
         insertafter: EOF
 
 ```
+{% endraw %}
 
 Once complete, commit and push your new playbook up into Gitea.
 

--- a/exercises/rhde_aw_120/3.1-boot-edge-device/README.md
+++ b/exercises/rhde_aw_120/3.1-boot-edge-device/README.md
@@ -14,7 +14,7 @@ In this exercise, we're going to use our customized ISO to provision our edge de
 
 If you have a monitor/keyboard available at your station, feel free to use them. If not, contact with the instructor for more information.
 
-> Note:
+> **Note**
 >
 > This exercise is for students with physical devices. If you do not have one and are instead virtualizing an edge device, proceed to the [next exercise](../3.2-boot-edge-vm).
 
@@ -27,7 +27,7 @@ On your linux system, use the `dd` command to copy the ISO to the USB device:
 dd if=~/generate-iso/rhde-ztp.iso of=/dev/sdz
 ```
 
-> Note:
+> **Note**
 > 
 > This operation does require root, and ensure that you're referencing at the correct device in the `of` parameter. More information can be found in the [RHEL Documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/assembly_creating-a-bootable-installation-medium_installing-rhel).
 
@@ -108,7 +108,7 @@ Once the file has been created, make the script executable and then run it the s
 
 After the script completes, you should have a new ISO called `rhde-ztp.iso` within this directory.
 
-> Note:
+> **Note**
 >
 > If the `mkisofs`, `isohybrid`, and `implantisomd5` commands aren't available, you may need to install the `genisoimage`, `syslinux`, and `isomd5sum` packages.
 

--- a/exercises/rhde_aw_120/3.4-rhde-os-intro/README.md
+++ b/exercises/rhde_aw_120/3.4-rhde-os-intro/README.md
@@ -23,7 +23,7 @@ Because of this, the operating system is more suited to edge deployments, and ca
 
 The exercise is optional, but if you wish, you can SSH into the edge device like any other system.
 
-> Note:
+> **Note**
 >
 > For virtualized edge devices, connect to the hypervisor over SSH. Then, attempt to access the edge devices using the IP address discovered in the Ansible Controller inventory variable. Their networking doesn't extend beyond the hypervisor.
 

--- a/exercises/rhde_aw_120/4.1-bare-metal-image/README.md
+++ b/exercises/rhde_aw_120/4.1-bare-metal-image/README.md
@@ -12,7 +12,7 @@ In this exercise, we'll review creating a new image via automation to host our b
 
 For a reminder on the application we're deploying, review [exercise 1.5](../1.5-application-intro).
 
-> Note:
+> **Note**
 >
 > We will be purposefully configuring the device incorrectly in this exercise. It is important to avoid performing these same configurations in production environments. While running applications is suitable on RHDE and can be secured approperately, this lab focuses on RHDE and not SELinux/fapolicyd/etc. In addition, this reinforces that migrating to containers helps simplify the securing of appliccations. In addition, EPEL is not supported by Red Hat.
 

--- a/exercises/rhde_aw_120/4.3-bare-metal-app-automation/README.md
+++ b/exercises/rhde_aw_120/4.3-bare-metal-app-automation/README.md
@@ -163,7 +163,7 @@ There are quite a few tasks that we have configured within this role previous: w
 
 Assuming these tasks run successfully, the simulate portion of our application will be up and running when the role is executed.
 
-> Note:
+> **Note**
 >
 > Previously, we installed packages onto the system "out of band", meaning that we pulled them directly to the system and had rpm-ostree apply them to the deployed image. This functionality exists and is useful for testing, such as in development environments; but, this is not a recommended practice. The proper flow is to add the packages to the image using Image Builder.
 

--- a/exercises/rhde_aw_120/4.4-deploy-bare-metal-app/README.md
+++ b/exercises/rhde_aw_120/4.4-deploy-bare-metal-app/README.md
@@ -90,7 +90,7 @@ Once the playbook completes, visit http://$(your-device-ip-address):1881/ui to v
 > Something like the following might do the trick:
 > ssh -L 1881:ip-address-of-the-virtual-edge:1881 student{your-number}@edge-manager.tech-exchange.emea.redhat-workshops.com
 
-Further thoughts: The deployment of the application could be added to the end of our provisioning workflow as soon as a device calls home to simplify the setup and configuration process.
+Further thoughts: The deployment of the application could be added to the end of our provisioning workflow as soon as a device calls home to simplify the setup and configuration process. We're not going to do that here, since we're about to tear it down and reprovision using a better methodology.
 
 ### Solutions
 

--- a/exercises/rhde_aw_120/4.4-deploy-bare-metal-app/README.md
+++ b/exercises/rhde_aw_120/4.4-deploy-bare-metal-app/README.md
@@ -29,7 +29,7 @@ Once complete, be sure to commit and push your changes up to the repo.
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 
@@ -84,7 +84,7 @@ As a reminder, the output of jobs can be reviewed on the **Jobs** tab.
 
 Once the playbook completes, visit http://$(your-device-ip-address):1881/ui to view the application running.
 
-> Note:
+> **Note**
 >
 > For virtualized edge devices, you'll need to use SSH tunneling or just curl the port to check for a response.
 > Something like the following might do the trick:

--- a/exercises/rhde_aw_120/4.5-cleanup-bare-metal-app/README.md
+++ b/exercises/rhde_aw_120/4.5-cleanup-bare-metal-app/README.md
@@ -87,7 +87,7 @@ Remember to commit and push your code up to Gitea when finished crafting this pl
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 

--- a/exercises/rhde_aw_120/5.1-containerized-image/README.md
+++ b/exercises/rhde_aw_120/5.1-containerized-image/README.md
@@ -37,7 +37,7 @@ Specifically, this image was customized with the following variables:
 
 ### Step 2 - Automated Device Update
 
-Proceed to [this exercise](../0.1-update-rhde/) for next steps on how to get your device updated to the correct image version.
+Proceed to [this exercise](../0.1-upgrade-rhde/) for next steps on how to get your device updated to the correct image version.
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
+++ b/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
@@ -45,7 +45,7 @@ spec:
 
 Here, we can see the four individual containers that will be run together in a pod. In addition, all traffic is kept internal to the pod except for accessing the WebUI on the UI service.
 
-In addition, in contrast to the bare metal deployment, these containers will not be running as root. Here, we've set them to run as the same user Ansible is using. However, this also can be customized.
+In addition, in contrast to the bare metal deployment, these containers will not be running as root. Here, we're going to set them to run as the same user Ansible is using. However, this also can be customized.
 
 ### Step 2 - Finishing Out Our Ansible Role
 

--- a/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
+++ b/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
@@ -103,9 +103,11 @@ Another highly recommended task to complete when deploying applications is to le
 
 [This documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers) includes more information on this topic.
 
-In addition, podman can generate systemd unit files. In this workshop, running `podman generate systemd --name process-control` will generate the files needed.
+Podman can generate systemd unit files. On your edge device, running `podman generate systemd --name process-control` will generate the files needed to stdout.
 
 If you have extra time, add automation around this process: after the pod is up and running, have podman generate the systemd unit files, capture the output of that command, then create the unit files and enable the newly created systemd service.
+
+Also consider that Kubernetes YAML can be directly paired with a systemd unit template in podman to rapidly define `podman play kube` systemd units. See [this blog post](https://www.redhat.com/sysadmin/kubernetes-workloads-podman-systemd) for more details.
 
 ---
 **Navigation**

--- a/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
+++ b/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
@@ -93,7 +93,7 @@ Remember to commit and push these new files to your git repository.
 
 ### Conclusion
 
-It should be noted that this deployment methodology is infinitly more secure and simple, and is generally a better way to deploy an application.
+It should be noted that this deployment methodology is infinitely more secure and simple, and is generally a better way to deploy an application.
 
 Not all applications are ready to be containerized, so bare metal deployments are still perfectly acceptable. However,remember to take the necessary steps to secure them, and when possible, attempt to containerize them.
 

--- a/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
+++ b/exercises/rhde_aw_120/5.3-containerized-app-automation/README.md
@@ -18,7 +18,7 @@ Return to your code repo and create a new role called `deploy_containerized_app`
 
 While this will look and feel like Kubernetes YAML, we'll also get to leverage the Ansible's jinja2 templating engine for more flexibility. This would allow for host or group specific variables, such as configuration custom specific environments including industrial sites or different geographical locations.
 
-Our application has been broken up into four containers which are pre-built for us. However, if you're interested, the Dockerfiles are available under the [Solutions](#solutions) section of this exercise.
+Our application has been broken up into four containers which are pre-built for us.
 
 Populate the contents of `process-control.yaml.j2` file within the `templates/` directory of the `deploy_containerized_app` role with the following
 

--- a/exercises/rhde_aw_120/5.4-deploy-containerized-app/README.md
+++ b/exercises/rhde_aw_120/5.4-deploy-containerized-app/README.md
@@ -28,7 +28,7 @@ Once complete, be sure to commit push your changes up to the git server.
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 
@@ -79,7 +79,7 @@ As a reminder, the output of jobs can be reviewed on the **Jobs** tab.
 
 Once the playbook completes, visit http://$(your-device-ip-address):1881/ui to view the running application.
 
-> Note:
+> **Note**
 >
 > For virtualized edge devices, you'll need to use SSH tunneling or just curl the port to check for a response.
 

--- a/exercises/rhde_aw_120/5.5-cleanup-containerized-app/README.md
+++ b/exercises/rhde_aw_120/5.5-cleanup-containerized-app/README.md
@@ -54,7 +54,7 @@ This playbook not only stops and removes our application deployment, but also cl
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 

--- a/exercises/rhde_aw_120/6.1-add-k8s/README.md
+++ b/exercises/rhde_aw_120/6.1-add-k8s/README.md
@@ -14,13 +14,13 @@ For a reminder on the application we're deploying, review [exercise 1.5](../1.5-
 
 > **Note**
 >
-> Portions of Device Edge are in tech preview. Because of this, a few steps are necessary before starting microshift. In addition, the kubernetes functionality will not work on devices that only have a wireless connection. If you have a physical device on wifi, consult with your instructor for next steps.
+> Kubernetes functionality will not work on devices that only have a wireless connection. If you have a physical device on WiFi, consult with your instructor for next steps.
 
 ### Step 1 - Reviewing the Requirements for the Application
 
 We're now going to deploy a Kubernetes-based application to our edge devices. To accomplish this, we'll need to add a very small footprint Kubernetes build to our devices to enable the running of k8s-based applications.
 
-A quick note: This was previously referred to as [Microshift](https://github.com/openshift/microshift), and is in tech preview. Because of this, we'll need to take a few additional steps to get things going to address concerns that should be cleared up before the GA date.
+A quick note: This is referred to in the upstream simply as [MicroShift](https://github.com/openshift/microshift). The workshops are not yet updated to leverage the 4.12 official releases of the Red Hat Build of MicroShift, supported by the Red Hat Device Edge SKU. Because of this, some functionality may be incomplete.
 
 In the interest of time, these steps have been completed for you and will be made available by the instructor. This image was composed using the [infra.osbuild](https://github.com/redhat-cop/infra.osbuild) Ansible collection, which takes a common set of variables and completely automates interactions with Image Builder.
 

--- a/exercises/rhde_aw_120/6.1-add-k8s/README.md
+++ b/exercises/rhde_aw_120/6.1-add-k8s/README.md
@@ -12,7 +12,7 @@ In this exercise, we'll review creating a new image via automation to host a kub
 
 For a reminder on the application we're deploying, review [exercise 1.5](../1.5-application-intro).
 
-> Note:
+> **Note**
 >
 > Portions of Device Edge are in tech preview. Because of this, a few steps are necessary before starting microshift. In addition, the kubernetes functionality will not work on devices that only have a wireless connection. If you have a physical device on wifi, consult with your instructor for next steps.
 

--- a/exercises/rhde_aw_120/6.3-startup-k8s/README.md
+++ b/exercises/rhde_aw_120/6.3-startup-k8s/README.md
@@ -87,7 +87,7 @@ Next, create a new playbook at `playbooks/bootstrap-kubernetes.yml` with the fol
 
 Here, we can see tasks to accomplish the goals of pushing out a corrected CRI-O config file, our pull secret, and fixing a bug. Once those have been completed, we can then start up microshift.
 
-> Note:
+> **Note**
 >
 > Our pull secret will be stored securely in Ansible Controller instead of being committed to our repo.
 
@@ -125,13 +125,13 @@ In the **Create New Credential** form, enter the following information:
 
 Remember to hit **Save**.
 
-> Note:
+> **Note**
 >
 > Your pull secret can be downloaded from [console.redhat.com](https://console.redhat.com/openshift/downloads).
 
 ### Step 3 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 

--- a/exercises/rhde_aw_120/6.5-deploy-k8s-app/README.md
+++ b/exercises/rhde_aw_120/6.5-deploy-k8s-app/README.md
@@ -45,7 +45,6 @@ Return to your code repo and create a new file at `playbooks/deploy-k8s-app.yml`
       ansible.builtin.copy:
         content: "{{ (kubeconfig_raw['content'] | b64decode).replace('127.0.0.1', ansible_host) }}"
         dest: /tmp/kubeconfig
-      delegate_to: localhost
     - name: allow API access
       ansible.posix.firewalld:
         port: 6443/tcp

--- a/exercises/rhde_aw_120/6.5-deploy-k8s-app/README.md
+++ b/exercises/rhde_aw_120/6.5-deploy-k8s-app/README.md
@@ -87,7 +87,7 @@ Remember to commit and push your new playbook up to the git repo.
 
 ### Step 2 - Creating a Job Template
 
-> Note:
+> **Note**
 >
 > Be sure to sync your project in Controller before attempting to create this job template.
 > Make sure also to disable edge device firewall to allow calling k8s apis

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -105,7 +105,8 @@ student_total: 10
 # Can be accessed at https://access.redhat.com/management/api
 offline_token: "your-token-here"
 
-# Required for podman authentication to registry.redhat.io
+# Required for RHSM registration and registry.redhat.io pulls - needs to be your full RHN username and password
+# https://www.redhat.com/wapps/ugc/register.html
 redhat_username: your-username
 redhat_password: your-password
 

--- a/roles/control_node/tasks/05_download_aap.yml
+++ b/roles/control_node/tasks/05_download_aap.yml
@@ -2,6 +2,7 @@
 
 - name: run from localhost
   delegate_to: localhost
+  become: false
   run_once: true
   block:
     - name: Generating an access token


### PR DESCRIPTION
- A few things to clean up inconsistent formatting
- Fixed a couple of misspellings
- Added a bit more clarity in places where I thought the lab guides were _too_ vague on accident, rather than by design
- Fixed up a few liquid template errors
- Removed references to non-existent things
- Fixed some syntax errors in some Ansible code blocks
- Added some clarity around a few provisioner variables that are not used as described
- Removed `become` on `delegate_to: localhost` block, removing need for passwordless sudo on the provisioning host
- Added some notes about the kube yaml systemd templates in one of the bonus sections talking about systemd units and podman