### PR TITLE
Remove scape bash var kickstart

### DIFF
--- a/roles/setup_gitea/templates/rhde_gitops/production-kickstart.ks.j2
+++ b/roles/setup_gitea/templates/rhde_gitops/production-kickstart.ks.j2
@@ -451,13 +451,13 @@ while true; do
     fi
 done
 while true
-do 
+do
   podman pull {{ apps.app2.registry }}/{{ apps.app2.image }}:{{ apps.app1.prodtag }}
   podman image list | grep {{ apps.app2.image }}
   if [ \$? -eq 0 ]
-  then 
+  then
     break
-  fi  
+  fi
 done
 EOF
 
@@ -545,9 +545,9 @@ sudo cat << 'EOF' > /etc/greenboot/check/required.d/01-check-packages.sh
 required_packages=("python3-pip" "python3-inotify" "git")
 
 # Check if each package is installed
-for package in "\${required_packages[@]}"; do
-    if ! rpm -q "\$package" &>/dev/null; then
-        echo "Error: \$package is not installed."
+for package in "${required_packages[@]}"; do
+    if ! rpm -q "$package" &>/dev/null; then
+        echo "Error: $package is not installed."
         exit 1
     fi
 done


### PR DESCRIPTION
The script 01-check-packages.sh referenced in the roles/setup_gitea/templates/rhde_gitops/production-kickstart.ks.j2 file should have the backslash removed before ${required_packages[@]} and $package variables. With the backslash, the array is treated as a string, adding the backslash to each package name. This prevents proper variable expansion, resulting in the literal string '$package' being passed to the rpm -q command instead of the actual package name. Consequently, the script fails to find the package and incorrectly reports that it is not installed. This cause that the non-k8s deployment greenboot health check fails always.
 

```
[pgoku@edge-manager-local ~]$ ssh ansible@192.168.40.30
ansible@192.168.40.30's password: 
Script '01-check-packages.sh' FAILURE (exit code '1'). Continuing...
Boot Status is RED - Health Check FAILURE!
SYSTEM is UNHEALTHY, but boot_counter is unset in grubenv. Manual intervention necessary.
Last login: Sun Apr 14 11:17:03 2024 from 192.168.40.1

[root@edge-525400d153f9 required.d]# bash -x 01-check-packages.sh 
+ required_packages=("python3-pip" "python3-inotify" "git")
+ for package in "${required_packages[@]}"
+ rpm -q python3-pip
+ for package in "${required_packages[@]}"
+ rpm -q python3-inotify
+ for package in "${required_packages[@]}"
+ rpm -q git
+ echo 'All required packages are installed.'
All required packages are installed.

[root@edge-525400d153f9 required.d]# reboot
Connection to 192.168.40.30 closed by remote host.
Connection to 192.168.40.30 closed.

[pgoku@edge-manager-local ~]$ ssh ansible@192.168.40.30
ansible@192.168.40.30's password: 
Boot Status is GREEN - Health Check SUCCESS
Last login: Sun Apr 14 11:25:29 2024 from 192.168.40.1
```



